### PR TITLE
functioning search API and fixed client bugs

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/src/app/api/advocates/advocates.service.ts
+++ b/src/app/api/advocates/advocates.service.ts
@@ -1,0 +1,76 @@
+import { AdvocateDetails, AdvocateSearchParams } from '@/types';
+import db from '../../../db';
+import {
+  advocates,
+  advocatesToSpecialities,
+  specialties,
+} from '../../../db/schema';
+import { and, asc, eq, gte, inArray, InferSelectModel, sql } from 'drizzle-orm';
+
+const MAX_PAGE_SIZE = 100;
+
+export const getAdvocates = async ({
+  page = 1,
+  pageSize = 10,
+  searchTerm,
+  specialtyIds,
+  yoeGte,
+}: AdvocateSearchParams) => {
+  const where = [];
+
+  if (specialtyIds?.length) {
+    const specializers = await getAdvocateIdsSpecializingIn(specialtyIds);
+
+    where.push(inArray(advocates.id, specializers));
+  }
+
+  if (searchTerm) {
+    /**
+     * we convert "hello world" --> "hello & world"
+     * so that FTS understands we're looking to match every token
+     */
+    const query = searchTerm.split(' ').join('&') + ':*'; // assume last word might not be complete as user is typing, so we add a wildcard
+    where.push(sql`${advocates.search} @@ to_tsquery('english', ${query})`);
+  }
+
+  if (yoeGte) {
+    where.push(gte(advocates.yearsOfExperience, yoeGte));
+  }
+
+  const searchResults = (await db
+    .select()
+    .from(advocates)
+    .where(and(...where))
+    .orderBy(asc(advocates.firstName))
+    .limit(Math.min(pageSize, MAX_PAGE_SIZE))
+    .offset((page - 1) * pageSize)) as AdvocateDetails[];
+
+  for (let advocate of searchResults) {
+    /** we can also lookup all relationships at once, but wanted to keep it simple for now */
+    advocate.specialties = await getAdvocateSpecialties(advocate.id);
+  }
+
+  return searchResults;
+};
+
+const getAdvocateIdsSpecializingIn = async (specialtyIds: number[]) => {
+  const specializers = await db
+    .select()
+    .from(advocatesToSpecialities)
+    .where(inArray(advocatesToSpecialities.specialtyId, specialtyIds));
+
+  return specializers.map((row) => row.advocateId);
+};
+
+const getAdvocateSpecialties = async (advocateId: number) => {
+  const results = await db
+    .select()
+    .from(advocatesToSpecialities)
+    .leftJoin(
+      specialties,
+      eq(advocatesToSpecialities.specialtyId, specialties.id)
+    )
+    .where(eq(advocatesToSpecialities.advocateId, advocateId));
+
+  return results.map((r) => r.specialties!);
+};

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,15 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import { getAdvocates } from './advocates.service';
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
 
-  const data = advocateData;
+  const advocates = await getAdvocates({
+    page: Number(searchParams.get('page')) || 1,
+    pageSize: Number(searchParams.get('pageSize')) || 10,
+    searchTerm: searchParams.get('search') || '',
+    specialtyIds: searchParams.getAll('specialties').map((id) => parseInt(id)),
+    yoeGte: Number(searchParams.get('yoeGte')) || undefined
+  });
 
-  return Response.json({ data });
+  return Response.json({ advocates });
 }

--- a/src/app/api/specialties/route.ts
+++ b/src/app/api/specialties/route.ts
@@ -1,0 +1,8 @@
+import { getSpecialties } from "./specialties.service";
+
+export async function GET(request: Request) {
+
+  const specialties = await getSpecialties();
+
+  return Response.json({ specialties });
+}

--- a/src/app/api/specialties/specialties.service.ts
+++ b/src/app/api/specialties/specialties.service.ts
@@ -1,0 +1,8 @@
+import db from '@/db';
+import { specialties } from '@/db/schema';
+
+export const getSpecialties = async () => {
+  const results = await db.select().from(specialties);
+
+  return results;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,48 +1,31 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
+import { AdvocateDetails } from '@/types';
+import { ChangeEventHandler, useEffect, useState } from 'react';
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [advocates, setAdvocates] = useState<AdvocateDetails[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
-    console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
+    fetch(`/api/advocates?page=1&search=${search}`).then((response) => {
       response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
+        setAdvocates(jsonResponse.advocates);
       });
     });
-  }, []);
+  }, [search]);
 
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
+  const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    setSearchText(event.target.value);
   };
 
   const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
+    setSearch(searchText);
   };
 
   return (
-    <main style={{ margin: "24px" }}>
+    <main style={{ margin: '24px' }}>
       <h1>Solace Advocates</h1>
       <br />
       <br />
@@ -51,32 +34,38 @@ export default function Home() {
         <p>
           Searching for: <span id="search-term"></span>
         </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
+        <input
+          style={{ border: '1px solid black' }}
+          onChange={onChange}
+          value={searchText}
+        />
+        <button onClick={onClick}>Search</button>
       </div>
       <br />
       <br />
       <table>
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>City</th>
+            <th>Degree</th>
+            <th>Specialties</th>
+            <th>Years of Experience</th>
+            <th>Phone Number</th>
+          </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div>{s.name}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+import { InferSelectModel } from 'drizzle-orm';
+import { advocates, specialties } from './db/schema';
+
+export type AdvocateSearchParams = {
+  page?: number;
+  pageSize?: number;
+  searchTerm?: string;
+  specialtyIds?: number[];
+  yoeGte?: number; // yearsOfExperience >= range queries
+};
+
+export type AdvocateDetails = InferSelectModel<typeof advocates> & {
+  specialties: InferSelectModel<typeof specialties>[];
+};


### PR DESCRIPTION
## Summary

After getting the initial data model in place, we are now setup to create an API which exposes the ability to search our database. The new APIs are as described below. I also briefly fixed some of the glaring bugs on the client just so that we now have a fairly working product, you can see a recorded demo below.

In general I made sure to support a variety of search and filtering capabilities, which is the primary function of our application. I also made to support pagination as we should always be limiting the results set in some way for performance reasons.

## API
- `GET /advocates` - Returns an initial list of advocates with their corresponding specialties
  - `?search=john` - Filters the result given a search term. This will utilize full text search on some of the core fields as 
mentioned in #1 
  - `?page=1&pageSize=10` - Support for basic pagination and variable page sizes 
  - `?specialties=3&specialties=7` - Allows for filter advocates by one or more specialties
- `GET /specialties` - Returns a list of available specialties (later will be utilized to create client-side filter)
  - The `id` returned can be used for the `specialties` filter of `/advocates` 

## API Demo

### Basic pagination
![image](https://github.com/user-attachments/assets/b321f959-e3fc-46e3-bd9e-22da7557634c)

### Search by mixture of first and last name, with wildcard support on the last word
![image](https://github.com/user-attachments/assets/c14bd656-4212-40ab-88bd-10722f66571f)

### Search by combination of degree + name characters
![image](https://github.com/user-attachments/assets/6741b7c6-dd29-4e24-9ae9-26bc2f75ebb4)

### Search by city
![image](https://github.com/user-attachments/assets/1a135476-b631-498a-8727-91204a604c72)

### Filter results based on range of years of experience, e.g. "greater than 19 years"
![image](https://github.com/user-attachments/assets/c42dc311-5137-4bc4-afb9-f15b35d090a1)

### Filter results based on specialties
![image](https://github.com/user-attachments/assets/ed854f73-4663-4d10-86e7-b9a110fe7e86)

### Return list of available specialties
![image](https://github.com/user-attachments/assets/807671cb-727c-4830-b41d-983b1c532fb8)

## Client Demo 
- Still ugly but somewhat functional, will be improved in the next PR
- This was done mostly to start testing the integration against the new API

https://github.com/user-attachments/assets/9f14df6c-4d38-4482-889f-1430b1824f4b

